### PR TITLE
docs: add path filter to build documentation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,10 @@ name: Documentation
 on:
   push:
     branches: [main]
+    paths:
+      - src/**
+      - docs/**
+      - mkdocs.yml
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
# 📄 Description

The documentation will be build only if changes are made in `src/` `docs/` and `mkdocs.yml`
