### PR TITLE
feat: add method to shift variables

### DIFF
--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -392,6 +392,10 @@ class Polynomial:
         -----
         If k = 0 a copy of the polynomial is returned.
 
+        The Python shift operators can be used as a syntactic sugar for this method.
+        `poly >> 3` is equivalent to `poly.shift(3)`, and `poly << 2` is equivalent to
+        `poly.shift(-2)`.
+
         This method is reversible as long as both directions are valid.
 
         - The statement `poly.shift(k).shift(-k)` will return a polynomial equal to the
@@ -409,6 +413,8 @@ class Polynomial:
         1 + 2*x_1 + 3*x_1^2
         >>> poly.shift(2)
         1 + 2*x_3 + 3*x_3^2
+        >>> poly >> 2 # equivalent syntax
+        1 + 2*x_3 + 3*x_3^2
 
         Removing empty variables (shift left), decreases the variable indices.
 
@@ -416,6 +422,8 @@ class Polynomial:
         >>> poly
         10*x_2 + 20*x_2^3 + 30*x_2^5
         >>> poly.shift(-1)
+        10*x_1 + 20*x_1^3 + 30*x_1^5
+        >>> poly << 1 # equivalent syntax
         10*x_1 + 20*x_1^3 + 30*x_1^5
         """
         if not isinstance(k, int):

--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -358,6 +358,66 @@ class Polynomial:
         return NotImplemented
 
     def shift(self, k: int = 1) -> Polynomial:
+        """Shifts the polynomial variables.
+
+        This method returns a new polynomial with its variables shifted.
+        A positive shift adds extra variables (increasing all variable indices).
+        A negative shift removes empty variables, but only if they are empty.
+
+
+        Parameters
+        ----------
+        k : int, optional
+            The shift count. If positive, adds `k` extra variables
+            (increase the variable indices). If negative, remove the first `abs(k)`
+            variables, but only if they are empty (all corresponding exponents
+            are zero).
+
+        Returns
+        -------
+        Polynomial
+            A new polynomial with shifted variables.
+
+        Raises
+        ------
+        TypeError
+            - If `k` is not an int.
+        ValueError
+            - If `k` is negative and the number of variables after shifting
+            would be less than one.
+            - If any of the first `abs(k)` variables are
+            not empty.
+
+        Notes
+        -----
+        If k = 0 a copy of the polynomial is returned.
+
+        This method is reversible as long as both directions are valid.
+
+        - The statement `poly.shift(k).shift(-k)` will return a polynomial equal to the
+        original object `poly`.
+
+        - Likewise, if `poly.shift(-k)` is possible, then applying `shift(k)` after it
+        will also return a copy of `poly`.
+
+        Examples
+        --------
+        Adding extra variables (shift right), increases the variable indices.
+
+        >>> poly = Polynomial.univariate([1, 2, 3])
+        >>> poly
+        1 + 2*x_1 + 3*x_1^2
+        >>> poly.shift(2)
+        1 + 2*x_3 + 3*x_3^2
+
+        Removing empty variables (shift left), decreases the variable indices.
+
+        >>> poly = Polynomial([[0, 1], [0, 3], [0, 5]], [10, 20, 30])
+        >>> poly
+        10*x_2 + 20*x_2^3 + 30*x_2^5
+        >>> poly.shift(-1)
+        10*x_1 + 20*x_1^3 + 30*x_1^5
+        """
         if not isinstance(k, int):
             msg = f"k must be an int, got {type(k)}."
             raise TypeError(msg)

--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -490,7 +490,7 @@ class Polynomial:
         ValueError
             - If the shift count (`other`) is negative.
         """
-        if not isinstance(other, int):
+        if not isinstance(other, int):  # pragma: no cover
             return NotImplemented
 
         if other < 0:
@@ -520,7 +520,7 @@ class Polynomial:
         ValueError
             - If the shift count (`other`) is negative.
         """
-        if not isinstance(other, int):
+        if not isinstance(other, int):  # pragma: no cover
             return NotImplemented
 
         if other < 0:

--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -400,3 +400,23 @@ class Polynomial:
             )
 
         return self.__class__(exponents, coefficients)
+
+    def __rshift__(self, other: object) -> Polynomial:
+        if not isinstance(other, int):
+            return NotImplemented
+
+        if other < 0:
+            msg = "Shift count must be non-negative."
+            raise ValueError(msg)
+
+        return self.shift(other)
+
+    def __lshift__(self, other: object) -> Polynomial:
+        if not isinstance(other, int):
+            return NotImplemented
+
+        if other < 0:
+            msg = "Shift count must be non-negative."
+            raise ValueError(msg)
+
+        return self.shift(-other)

--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -470,6 +470,26 @@ class Polynomial:
         return self.__class__(exponents, coefficients)
 
     def __rshift__(self, other: int) -> Polynomial:
+        """Adds extra variables to the Polynomial.
+
+        A shorthand for `Polynomial.shift(k)` with `k > 0` using the right shift
+        operator (`>>`). For more details, see the `Polynomial.shift()` method.
+
+        Parameters
+        ----------
+        other : int
+            The shift count. Must be a non-negative integer.
+
+        Returns
+        -------
+        Polynomial
+            A new polynomial with shifted variables.
+
+        Raises
+        ------
+        ValueError
+            - If the shift count (`other`) is negative.
+        """
         if not isinstance(other, int):
             return NotImplemented
 
@@ -480,6 +500,26 @@ class Polynomial:
         return self.shift(other)
 
     def __lshift__(self, other: int) -> Polynomial:
+        """Removes empty variables of the Polynomial.
+
+        A shorthand for `Polynomial.shift(k)` with `k < 0` using the left shift
+        operator (`<<`). For more details, see the `Polynomial.shift()` method.
+
+        Parameters
+        ----------
+        other : int
+            The shift count. Must be a non-negative integer.
+
+        Returns
+        -------
+        Polynomial
+            A new polynomial with shifted variables.
+
+        Raises
+        ------
+        ValueError
+            - If the shift count (`other`) is negative.
+        """
         if not isinstance(other, int):
             return NotImplemented
 

--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -469,7 +469,7 @@ class Polynomial:
 
         return self.__class__(exponents, coefficients)
 
-    def __rshift__(self, other: object) -> Polynomial:
+    def __rshift__(self, other: int) -> Polynomial:
         if not isinstance(other, int):
             return NotImplemented
 
@@ -479,7 +479,7 @@ class Polynomial:
 
         return self.shift(other)
 
-    def __lshift__(self, other: object) -> Polynomial:
+    def __lshift__(self, other: int) -> Polynomial:
         if not isinstance(other, int):
             return NotImplemented
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -144,3 +144,15 @@ def test_polynomial_shift_invalid_left_shift(input_k):
     poly = Polynomial([[0, 0], [0, 1], [1, 0]], [10, 20, 30])
     with pytest.raises(ValueError):
         poly.shift(input_k)
+
+
+def test_polynomial_right_shift_inverse():
+    poly = Polynomial.univariate([1, 2, 3])
+
+    assert poly.shift(1).shift(-1) == poly
+
+
+def test_polynomial_left_shift_inverse():
+    poly = Polynomial([[0, 0], [0, 3], [0, 5]], [10, 20, 30])
+
+    assert poly.shift(-1).shift(1) == poly

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -115,3 +115,32 @@ def test_polynomial_ordering_exceptions(operation, other):
     poly = Polynomial.univariate([1, 2, 3])
     with pytest.raises(TypeError):
         operation(poly, other)
+
+
+@pytest.mark.parametrize("input_data", (np.array(1), "polyany", None, [1]))
+def test_polynomial_shift_non_int_input(input_data):
+    poly = Polynomial.univariate([1, 2, 3])
+    with pytest.raises(TypeError):
+        poly.shift(input_data)
+
+
+@pytest.mark.parametrize("operation", [operator.lshift, operator.rshift])
+def test_polynomial_shift_wrapper_negative_input(operation):
+    poly = Polynomial.univariate([1, 2, 3])
+    with pytest.raises(ValueError):
+        operation(poly, -1)
+
+
+@pytest.mark.parametrize(
+    "input_k",
+    (
+        # has nonzero coefficients
+        -1,
+        # at least one variable must remain
+        -2,
+    ),
+)
+def test_polynomial_shift_invalid_left_shift(input_k):
+    poly = Polynomial([[0, 0], [0, 1], [1, 0]], [10, 20, 30])
+    with pytest.raises(ValueError):
+        poly.shift(input_k)


### PR DESCRIPTION
# 📄 Description

Implements a method that **shifts the variables** of a polynomial. If shift count is positive adds "extra" variables (increasing the variable indices), if negative, removes variables at the beginning **only if** they are empty (all corresponding exponents are zero) . This method is useful for simplifying algebraic operations on polynomials defined over different variable domains.

## 🧪  Examples

- `1 + x_1 + 3*x_1^2 ` gets shifted by `3`  becomes  `1 + x_4 + 3*x_4^2`
- `1 + x_4 + 3*x_4^2` gets shifted by `-3` becomes  `1 + x_1 + 3*x_1^2`

## 🧠 Intended Future Behavior

To sum `1 + x_1 + 3*x_1^2` with `3 + 2*x_2 + 5*x_2^2` its simpler to shift:

```py
>>> poly1 = Polynomial.univariate([1, 1, 3])
>>> poly2 = Polynomial.univariate([3, 2, 5])
>>> poly1 + poly2.shift(1)
4 + x_1 + 2*x_2 + 3*x_1^2 + 5*x_2^2
```

or

```py
>>> poly1 + (poly2 >> 1)
4 + x_1 + 2*x_2 + 3*x_1^2 + 5*x_2^2
```

# 🎯 Objectives

1. Implement the shift method
2. Implement the operators `<<`, `>>` as wrappers for `shift()`
3. Add unit tests
5. Document the new method

# ✅ Tasks

- [x] Implementation of `shift()`
- [x] Implementation of `<<`, `>>` operators
- [x] Write unit tests
- [x] Write the documentation
