### PR TITLE
feat(exponents): sparse representation

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -197,7 +197,7 @@ Comparison with other types (sequences, scalars, NumPy arrays) always returns [`
 
 ???+ tip "Example"
 
-    Internally, the polynomial object stores a complete representation[^2] of the coefficients and exponents. These are stored in an **ordered way**, meaning that a polynomial is created **regardless of the order** of the input coefficients and exponents.
+    Internally, the polynomial object stores the coefficients and exponents in an **ordered way**, meaning that a polynomial is created **regardless of the order** of the input coefficients and exponents.
 
     ```py
     >>> poly1 = Polynomial([[0, 0], [1, 0], [0, 1]], [1, 2, 3])
@@ -205,4 +205,3 @@ Comparison with other types (sequences, scalars, NumPy arrays) always returns [`
     >>> poly1 == poly2
     True
     ```
-[^2]: A complete representation includes all possible monomials up to the total degree of the polynomial.

--- a/src/polyany/exponents.py
+++ b/src/polyany/exponents.py
@@ -1,43 +1,8 @@
-import math
-from collections.abc import Generator
-
 import numpy as np
 
 
-def get_full_exponents(n_vars: int, degree: int) -> np.ndarray:
-    count = math.comb(n_vars + degree, degree)
-    dtype = np.int16 if n_vars == 1 else (np.int16, n_vars)
+def get_quadratic_exponents(n_vars: int) -> np.ndarray:
+    eye = np.eye(n_vars, dtype=np.int16)
+    i, j = np.triu_indices(n_vars)
 
-    return np.fromiter(
-        _full_exponents_generator(n_vars, degree), dtype=dtype, count=count
-    ).reshape(-1, n_vars)
-
-
-def _full_exponents_generator(
-    n_vars: int,
-    degree: int,
-    var_index: int = 0,
-    current_exponents: list[int] | None = None,
-    remaining_degree: int | None = None,
-) -> Generator[tuple[int, ...] | int]:
-    if current_exponents is None:
-        current_exponents = [0] * n_vars
-    if remaining_degree is None:
-        remaining_degree = degree
-
-    if var_index == n_vars:
-        if n_vars == 1:
-            yield current_exponents[0]
-        else:
-            yield tuple(current_exponents)
-        return
-
-    for current_degree in range(remaining_degree + 1):
-        current_exponents[var_index] = current_degree
-        yield from _full_exponents_generator(
-            n_vars,
-            degree,
-            var_index + 1,
-            current_exponents,
-            remaining_degree - current_degree,
-        )
+    return eye[i] + eye[j]

--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -89,7 +89,7 @@ class Polynomial:
         self.n_vars = input_exponents.shape[1]
         self.degree = np.max(np.sum(input_exponents, axis=1)).item()
 
-        self.exponents, self.coefficients = self._full_representation(
+        self.exponents, self.coefficients = self._sort_inputs(
             input_exponents, input_coefficients
         )
 
@@ -187,27 +187,13 @@ class Polynomial:
 
         return "".join(monomials)
 
-    def _full_representation(
+    def _sort_inputs(
         self, exponents: np.ndarray, coefficients: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray]:
-        n_monomials = len(exponents)
+        monomials_degree = np.sum(exponents, axis=1)
+        sorted_idx = np.lexsort((*exponents.T, monomials_degree))
 
-        input_monomials = {
-            tuple(exponents[i]): coefficients[i] for i in range(n_monomials)
-        }
-
-        full_exponents = get_full_exponents(self.n_vars, self.degree)
-
-        full_coefficients = np.array(
-            [input_monomials.get(tuple(exponent), 0.0) for exponent in full_exponents]
-        )
-
-        monomials_degree = np.sum(full_exponents, axis=1)
-        sorted_idx = np.lexsort((*full_exponents.T, monomials_degree))
-        full_exponents = full_exponents[sorted_idx]
-        full_coefficients = full_coefficients[sorted_idx]
-
-        return full_exponents, full_coefficients
+        return exponents[sorted_idx], coefficients[sorted_idx]
 
     @classmethod
     def univariate(cls, coefficients: ArrayLike) -> Polynomial:

--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 from numpy.typing import ArrayLike
 
-from .exponents import get_full_exponents
+from .exponents import get_quadratic_exponents
 
 
 class Polynomial:
@@ -279,7 +279,7 @@ class Polynomial:
         """
         try:
             converted_matrix = np.asarray(matrix).astype(
-                dtype=np.float64, casting="safe"
+                dtype=np.float64, casting="safe", copy=True
             )
         except Exception as e:
             msg = (
@@ -301,18 +301,15 @@ class Polynomial:
 
             converted_matrix = (converted_matrix + converted_matrix.T) / 2
 
-        degree = 2
         n_vars = len(converted_matrix)
+        index = np.arange(n_vars)
 
-        upper_plus_one_mask = np.arange(n_vars).reshape(-1, 1) < np.arange(n_vars)
-        upper_matrix = np.where(
-            upper_plus_one_mask, 2 * converted_matrix, converted_matrix
-        )
-        coefficients = np.flipud(upper_matrix[np.triu_indices(n_vars)])
+        upper_triangular_mask = index.reshape(-1, 1) < index
+        converted_matrix[upper_triangular_mask] *= 2
+        np.fill_diagonal(upper_triangular_mask, val=True)
+        coefficients = converted_matrix[upper_triangular_mask]
 
-        full_exponents = get_full_exponents(n_vars, degree)
-        degree_mask = np.sum(full_exponents, axis=1) == degree
-        exponents = full_exponents[degree_mask]
+        exponents = get_quadratic_exponents(n_vars)
 
         return cls(exponents, coefficients)
 

--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -36,7 +36,7 @@ class Polynomial:
         Total degree of the polynomial.
     exponents : np.ndarray
         A NumPy 2D-array representing the exponents
-        of the complete polynomial.
+        of the polynomial.
     coefficients : np.ndarray
         A NumPy 1D-array with the corresponding coefficients.
 
@@ -56,10 +56,6 @@ class Polynomial:
 
     Notes
     -----
-    Internally, the polynomial stores a complete representation, i.e., it includes all
-    possible monomials up to the given `degree`. Both `exponents` and `coefficients` are
-    stored accordingly.
-
     The current implementation allows coefficients to be complex numbers,
     but complex polynomials are not yet officially supported and may produce
     unexpected behavior.


### PR DESCRIPTION
# 📄 Description

This PR refactors the internal representation of polynomial exponents and coefficients.  The previous implementation stored all terms of the complete polynomial, which resulted in unnecessary memory usage and performance issues — especially for large polynomials

The new approach adopts a sparse representation that stores only the explicitly provided terms (exponents and coefficients) in a ordered way.

# 🎯 Objectives

- Optimize memory usage by switching to a sparse representation
- Improve performance for large-scale polynomials
- Update related documentation

# ✅ Tasks

- [x] Refactor internal data structures
- [x] Ensure test coverage
- [x] Revise documentation
