### PR TITLE
fix: polynomial evaluation without constant terms

### DIFF
--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -372,7 +372,9 @@ class Polynomial:
             raise ValueError(msg)
 
         if np.all(converted_point == 0):
-            return self.coefficients[0]
+            if np.all(self.exponents[0] == 0):
+                return self.coefficients[0]
+            return np.float64(0)
 
         return self.coefficients @ np.prod(
             np.power(converted_point, self.exponents), axis=1

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -17,8 +17,26 @@ from polyany import Polynomial
         ([1.9793, -4.477, -1.6816], 299.4298549970985),
     ],
 )
-def test_polynomial_eval(input_data, expected_output):
+def test_polynomial_eval_with_constant_term(input_data, expected_output):
     poly = Polynomial([[0, 0, 0], [0, 1, 0], [1, 2, 0], [2, 0, 2]], [-2, 5, 9, -3])
+
+    assert np.isclose(poly(input_data), expected_output)
+
+
+@pytest.mark.parametrize(
+    "input_data,expected_output",
+    [
+        ([0, 0, 0], 0),
+        ([4.5717, -0.7824, 1.5574], 1028.66970372905),
+        ([-0.1462, 4.1574, -4.6429], 966.154570347007),
+        ([3.0028, 2.9221, 3.4913], 13929.5674925524),
+        ([-3.5811, 4.5949, 4.3399], -42068.4310265224),
+    ],
+)
+def test_polynomial_eval_without_constant_term(input_data, expected_output):
+    poly = Polynomial(
+        [[0, 1, 2], [1, 2, 3], [2, 2, 2], [3, 2, 1]], [3.14, 2.6, 3.1, 10]
+    )
 
     assert np.isclose(poly(input_data), expected_output)
 


### PR DESCRIPTION
# 📄 Description

Fix the implementation of `__call__` when the polynomial has no constant term. Add test cases for polynomial evaluation without constant terms.