### PR TITLE
feat: add method to prune empty monomials

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -210,7 +210,7 @@ Comparison with other types (sequences, scalars, NumPy arrays) always returns [`
 
 Pruning is the process of removing **empty monomials** of a polynomial. The
 [`Polynomial`][polyany.Polynomial] object stores the exponents and coefficients
-provided by the user.
+provided by the user in a **ordered way**.
 
 ```numpy
 >>> poly = Polynomial([[0, 0], [0, 1], [1, 0], [1, 1]], [1, 0, 2, 0])
@@ -233,12 +233,12 @@ To prune a polynomial, use the [`prune`][polyany.Polynomial.prune] method:
 >>> pruned = poly.prune()
 >>> pruned.exponents
 array([[0, 0],
-       [0, 1]])
+       [1, 0]])
 >>> pruned.coefficients
 array([1., 2.])
 ```
 
-The pruned polynomial retains only the first and third term, which are the
+The pruned polynomial retains only the first and second term, which are the
 non-empty monomials.
 
 ## :heavy_plus_sign: Addition and subtraction

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -206,6 +206,41 @@ Comparison with other types (sequences, scalars, NumPy arrays) always returns [`
     True
     ```
 
+## :scissors: Pruning
+
+Pruning is the process of removing **empty monomials** of a polynomial. The
+[`Polynomial`][polyany.Polynomial] object stores the exponents and coefficients
+provided by the user.
+
+```numpy
+>>> poly = Polynomial([[0, 0], [0, 1], [1, 0], [1, 1]], [1, 0, 2, 0])
+>>> poly.exponents
+array([[0, 0],
+       [1, 0],
+       [0, 1],
+       [1, 1]])
+>>> poly.coefficients
+array([1., 2., 0., 0.])
+```
+
+When a polynomial is pruned, all empty monomials are removed, that is, the entries in
+`exponents` whose associated coefficients are  exactly zero, which have no effect
+on the polynomial behavior.
+
+To prune a polynomial, use the [`prune`][polyany.Polynomial.prune] method:
+
+```numpy
+>>> pruned = poly.prune()
+>>> pruned.exponents
+array([[0, 0],
+       [0, 1]])
+>>> pruned.coefficients
+array([1., 2.])
+```
+
+The pruned polynomial retains only the first and third term, which are the
+non-empty monomials.
+
 ## :heavy_plus_sign: Addition and subtraction
 
 In {{ polyany }}, Polynomial objects can be added or subtracted with scalars[^2] and other polynomials.

--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -313,6 +313,41 @@ class Polynomial:
 
         return cls(exponents, coefficients)
 
+    def prune(self) -> Polynomial:
+        """Prune the empty monomials of a polynomial.
+
+        Removes all monomials whose associated coefficients are exactly zero.
+
+        Returns
+        -------
+        Polynomial
+            A pruned polynomial, containing only monomials with non-zero coefficients.
+
+        Examples
+        --------
+        >>> poly = Polynomial.univariate([1, 0, 0, 1])
+        >>> poly.exponents
+        array([[0],
+               [1],
+               [2],
+               [3]])
+
+        This polynomial has four terms, but only the first and last have a
+        non-zero coefficient.
+
+        >>> pruned = poly.prune()
+        >>> pruned.exponents
+        array([[0],
+               [3]])
+
+        The result keeps only the non-empty monomials, discarding all others.
+        """
+        non_empty_mask = self.coefficients != 0
+
+        return self.__class__(
+            self.exponents[non_empty_mask], self.coefficients[non_empty_mask]
+        )
+
     def __call__(self, point: ArrayLike) -> np.float64:
         """Evaluate the polynomial at a given point
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -306,3 +306,15 @@ def test_polynomial_reflected_sub_scalar(scalar, expected_coefficient):
     expected = Polynomial.univariate(expected_coefficient)
 
     assert (scalar - poly) == expected
+
+
+def test_polynomial_prune():
+    pruned = Polynomial(
+        [[0, 0, 0], [0, 0, 1], [0, 1, 0], [1, 0, 0]], [1, 0, 3, 0]
+    ).prune()
+
+    expected_exponents = [[0, 0, 0], [0, 1, 0]]
+    expected_coefficients = [1, 3]
+
+    assert np.array_equal(pruned.exponents, expected_exponents)
+    assert np.array_equal(pruned.coefficients, expected_coefficients)


### PR DESCRIPTION
# 📄 Description

Implements the `prune` method to remove empty monomials of polynomials. 

# 🎯 Objectives

1. Implement the `prune` method
2. Ensure full test coverage
3. Document the new method

# ✅ Tasks

- [x] Implementation
- [x] Tests
- [x] Documentation
