### PR TITLE
fix(prune): return zeros polynomial when all coefficients are zero

### DIFF
--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -392,6 +392,9 @@ class Polynomial:
         """
         non_empty_mask = self.coefficients != 0
 
+        if not np.any(non_empty_mask):
+            return self.__class__.zeros(self.n_vars)
+
         return self.__class__(
             self.exponents[non_empty_mask], self.coefficients[non_empty_mask]
         )

--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -371,6 +371,11 @@ class Polynomial:
         Polynomial
             A pruned polynomial, containing only monomials with non-zero coefficients.
 
+        Notes
+        -----
+        If all coefficients are zero, a [`zeros`][polyany.Polynomial.zeros] polynomial
+        with the same number of variables is returned.
+
         Examples
         --------
         >>> poly = Polynomial.univariate([1, 0, 0, 1])

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -320,7 +320,7 @@ def test_polynomial_prune():
     assert np.array_equal(pruned.coefficients, expected_coefficients)
 
 
-def test_polynomial_prune_all_empty_polynomial():
+def test_polynomial_prune_all_zero_coefficients():
     poly = Polynomial.univariate([0, 0, 0])
 
     assert poly.prune() == Polynomial.zeros(1)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -318,3 +318,9 @@ def test_polynomial_prune():
 
     assert np.array_equal(pruned.exponents, expected_exponents)
     assert np.array_equal(pruned.coefficients, expected_coefficients)
+
+
+def test_polynomial_prune_all_empty_polynomial():
+    poly = Polynomial.univariate([0, 0, 0])
+
+    assert poly.prune() == Polynomial.zeros(1)


### PR DESCRIPTION
# 📄 Description

Fix the `prune` method when all coefficients are zero. In this case, the method will return a `zeros` (#29) polynomial with the same number of variables.

Relates to #27

# 🎯 Objectives

1. Fix the `prune` method
2. Add a test case
3. Document the case in docstring

# ✅ Tasks

- [x] Correction
- [x] Test
- [x] Documentation
