### PR TITLE
fix: reject empty arrays in polynomial creation

### DIFF
--- a/src/polyany/base.py
+++ b/src/polyany/base.py
@@ -79,6 +79,10 @@ class BasePolynomial(ABC):
             msg = f"Exponents must have 2 dimensions, got {converted_exponents.ndim}."
             raise ValueError(msg)
 
+        if converted_exponents.size == 0:
+            msg = "Exponents must have at least one element, got 0."
+            raise ValueError(msg)
+
         if not np.all(converted_exponents >= 0):
             msg = (
                 "PolyAny is not yet able to handle nonlinear polynomials. "

--- a/src/polyany/matrix.py
+++ b/src/polyany/matrix.py
@@ -113,6 +113,10 @@ class MatrixPolynomial(BasePolynomial):
             )
             raise ValueError(msg)
 
+        if converted_coefficients.size == 0:
+            msg = "Coefficients must have at least one element, got 0."
+            raise ValueError(msg)
+
         return converted_coefficients
 
     def __repr__(self) -> str:

--- a/src/polyany/polynomial.py
+++ b/src/polyany/polynomial.py
@@ -102,6 +102,10 @@ class Polynomial(BasePolynomial):
             )
             raise ValueError(msg)
 
+        if converted_coefficients.size == 0:
+            msg = "Coefficients must have at least one element, got 0."
+            raise ValueError(msg)
+
         return converted_coefficients
 
     def __repr__(self) -> str:

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -73,6 +73,10 @@ def test_polynomial_latex_representation(
         (([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0]], [[-1, 2, 33]]), TypeError),
         # exponents without 2 dimensions
         (([1, 2, 3], [10, 11, 12]), ValueError),
+        # empty exponents
+        ((np.zeros((1, 0), dtype=np.int_), [1]), ValueError),
+        # empty exponents
+        ((np.array([], dtype=np.int_).reshape(0, 1), [1]), ValueError),
         # coefficients without 1 dimension
         (([[0, 0], [1, 0], [0, 1]], [[1, 2], [3, 4]]), ValueError),
         # coefficients without 1 dimension

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -81,6 +81,8 @@ def test_polynomial_latex_representation(
         (([[0, 0], [1, 0], [0, 1]], [[1, 2], [3, 4]]), ValueError),
         # coefficients without 1 dimension
         (([[0, 0], [1, 0], [0, 1]], [[1, 2, 3]]), ValueError),
+        # empty coefficients
+        (([[0]], np.array([], dtype=np.float64)), ValueError),
         # scalar coefficient
         (([[0, 0]], 0), ValueError),
         # non unique exponents
@@ -215,6 +217,10 @@ def test_matrix_polynomial_string_representation(input_data, expected_string):
         (([[0, 0], [1, 0], [0, 1]], [[1, 2], [3, 4]]), ValueError),
         # matrix coefficients without 3 dimensions
         (([[0, 0], [1, 0], [0, 1]], [[1, 2, 3]]), ValueError),
+        # empty coefficient
+        (([[0]], np.zeros((1, 0, 1))), ValueError),
+        # empty coefficient
+        (([[0]], np.array([], dtype=np.float64).reshape(1, 0, 1)), ValueError),
         # non safe-convertible coefficient to float
         (([[0, 0]], [[["1"]]]), TypeError),
     ],


### PR DESCRIPTION
# 📄 Description

Add a cause to ensure that the input arrays have at least one element in `_sanitize_exponents` and `_sanitize_coefficients`.

Closes: #142 

# 🎯 Objectives

1. Fix the bug
2. Add tests

# ✅ Tasks

- [x] Fix
- [x] Tests
